### PR TITLE
feat: Register and handle commands

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+quote_type = single

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-APPLICATION_ID=dontknowifthisisneeded
-PUBLIC_KEY=dontknowifthisisneeded
-TOKEN=SOMETOKEN
+APPLICATION_ID=your_application_id
+GUILD_ID=your_guild_id
+TOKEN=your_bot_token

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,17 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"]
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "ts-node src/Bot.ts"
+    "start": "ts-node src/Bot.ts",
+    "lint": "eslint --ext .js,.ts,.jsx,.tsx src",
+    "format": "prettier --write src/**/*.{js,jsx,ts,tsx}"
   },
   "keywords": [],
   "author": "",
@@ -15,7 +17,11 @@
   },
   "devDependencies": {
     "@types/node": "^18.14.6",
+    "@typescript-eslint/eslint-plugin": "^5.54.1",
+    "@typescript-eslint/parser": "^5.54.1",
     "eslint": "^8.35.0",
+    "eslint-config-prettier": "^8.7.0",
+    "prettier": "^2.8.4",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,11 +2,14 @@ lockfileVersion: 5.4
 
 specifiers:
   '@types/node': ^18.14.6
+  '@typescript-eslint/eslint-plugin': ^5.54.1
+  '@typescript-eslint/parser': ^5.54.1
   discord.js: ^14.7.1
   dotenv: ^16.0.3
   eslint: ^8.35.0
+  eslint-config-prettier: ^8.7.0
+  prettier: ^2.8.4
   ts-node: ^10.9.1
-  tslib: ^2.5.0
   typescript: ^4.9.5
 
 dependencies:
@@ -15,9 +18,12 @@ dependencies:
 
 devDependencies:
   '@types/node': 18.14.6
+  '@typescript-eslint/eslint-plugin': 5.54.1_mlk7dnz565t663n4razh6a6v6i
+  '@typescript-eslint/parser': 5.54.1_ycpbpc6yetojsgtrx3mwntkhsu
   eslint: 8.35.0
+  eslint-config-prettier: 8.7.0_eslint@8.35.0
+  prettier: 2.8.4
   ts-node: 10.9.1_alpjt73dvgv6kni625hu7f2l4m
-  tslib: 2.5.0
   typescript: 4.9.5
 
 packages:
@@ -182,14 +188,152 @@ packages:
     resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
     dev: true
 
+  /@types/json-schema/7.0.11:
+    resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
+    dev: true
+
   /@types/node/18.14.6:
     resolution: {integrity: sha512-93+VvleD3mXwlLI/xASjw0FzKcwzl3OdTCzm1LaRfqgS21gfFtK3zDXM5Op9TeeMsJVOaJ2VRDpT9q4Y3d0AvA==}
+
+  /@types/semver/7.3.13:
+    resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
+    dev: true
 
   /@types/ws/8.5.4:
     resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
     dependencies:
       '@types/node': 18.14.6
     dev: false
+
+  /@typescript-eslint/eslint-plugin/5.54.1_mlk7dnz565t663n4razh6a6v6i:
+    resolution: {integrity: sha512-a2RQAkosH3d3ZIV08s3DcL/mcGc2M/UC528VkPULFxR9VnVPT8pBu0IyBAJJmVsCmhVfwQX1v6q+QGnmSe1bew==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 5.54.1_ycpbpc6yetojsgtrx3mwntkhsu
+      '@typescript-eslint/scope-manager': 5.54.1
+      '@typescript-eslint/type-utils': 5.54.1_ycpbpc6yetojsgtrx3mwntkhsu
+      '@typescript-eslint/utils': 5.54.1_ycpbpc6yetojsgtrx3mwntkhsu
+      debug: 4.3.4
+      eslint: 8.35.0
+      grapheme-splitter: 1.0.4
+      ignore: 5.2.4
+      natural-compare-lite: 1.4.0
+      regexpp: 3.2.0
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/parser/5.54.1_ycpbpc6yetojsgtrx3mwntkhsu:
+    resolution: {integrity: sha512-8zaIXJp/nG9Ff9vQNh7TI+C3nA6q6iIsGJ4B4L6MhZ7mHnTMR4YP5vp2xydmFXIy8rpyIVbNAG44871LMt6ujg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.54.1
+      '@typescript-eslint/types': 5.54.1
+      '@typescript-eslint/typescript-estree': 5.54.1_typescript@4.9.5
+      debug: 4.3.4
+      eslint: 8.35.0
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/scope-manager/5.54.1:
+    resolution: {integrity: sha512-zWKuGliXxvuxyM71UA/EcPxaviw39dB2504LqAmFDjmkpO8qNLHcmzlh6pbHs1h/7YQ9bnsO8CCcYCSA8sykUg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.54.1
+      '@typescript-eslint/visitor-keys': 5.54.1
+    dev: true
+
+  /@typescript-eslint/type-utils/5.54.1_ycpbpc6yetojsgtrx3mwntkhsu:
+    resolution: {integrity: sha512-WREHsTz0GqVYLIbzIZYbmUUr95DKEKIXZNH57W3s+4bVnuF1TKe2jH8ZNH8rO1CeMY3U4j4UQeqPNkHMiGem3g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/typescript-estree': 5.54.1_typescript@4.9.5
+      '@typescript-eslint/utils': 5.54.1_ycpbpc6yetojsgtrx3mwntkhsu
+      debug: 4.3.4
+      eslint: 8.35.0
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/types/5.54.1:
+    resolution: {integrity: sha512-G9+1vVazrfAfbtmCapJX8jRo2E4MDXxgm/IMOF4oGh3kq7XuK3JRkOg6y2Qu1VsTRmWETyTkWt1wxy7X7/yLkw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/typescript-estree/5.54.1_typescript@4.9.5:
+    resolution: {integrity: sha512-bjK5t+S6ffHnVwA0qRPTZrxKSaFYocwFIkZx5k7pvWfsB1I57pO/0M0Skatzzw1sCkjJ83AfGTL0oFIFiDX3bg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 5.54.1
+      '@typescript-eslint/visitor-keys': 5.54.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.3.8
+      tsutils: 3.21.0_typescript@4.9.5
+      typescript: 4.9.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/utils/5.54.1_ycpbpc6yetojsgtrx3mwntkhsu:
+    resolution: {integrity: sha512-IY5dyQM8XD1zfDe5X8jegX6r2EVU5o/WJnLu/znLPWCBF7KNGC+adacXnt5jEYS9JixDcoccI6CvE4RCjHMzCQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+    dependencies:
+      '@types/json-schema': 7.0.11
+      '@types/semver': 7.3.13
+      '@typescript-eslint/scope-manager': 5.54.1
+      '@typescript-eslint/types': 5.54.1
+      '@typescript-eslint/typescript-estree': 5.54.1_typescript@4.9.5
+      eslint: 8.35.0
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0_eslint@8.35.0
+      semver: 7.3.8
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+    dev: true
+
+  /@typescript-eslint/visitor-keys/5.54.1:
+    resolution: {integrity: sha512-q8iSoHTgwCfgcRJ2l2x+xCbu8nBlRAlsQ33k24Adj8eoVBE0f8dUeI+bAa8F84Mv05UGbAx57g2zrRsYIooqQg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dependencies:
+      '@typescript-eslint/types': 5.54.1
+      eslint-visitor-keys: 3.3.0
+    dev: true
 
   /acorn-jsx/5.3.2_acorn@8.8.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -239,6 +383,11 @@ packages:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: true
 
+  /array-union/2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+    dev: true
+
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
@@ -248,6 +397,13 @@ packages:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+    dev: true
+
+  /braces/3.0.2:
+    resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
+    engines: {node: '>=8'}
+    dependencies:
+      fill-range: 7.0.1
     dev: true
 
   /busboy/1.6.0:
@@ -319,6 +475,13 @@ packages:
     engines: {node: '>=0.3.1'}
     dev: true
 
+  /dir-glob/3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+    dependencies:
+      path-type: 4.0.0
+    dev: true
+
   /discord-api-types/0.37.35:
     resolution: {integrity: sha512-iyKZ/82k7FX3lcmHiAvvWu5TmyfVo78RtghBV/YsehK6CID83k5SI03DKKopBcln+TiEIYw5MGgq7SJXSpNzMg==}
     dev: false
@@ -359,6 +522,23 @@ packages:
   /escape-string-regexp/4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /eslint-config-prettier/8.7.0_eslint@8.35.0:
+    resolution: {integrity: sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+    dependencies:
+      eslint: 8.35.0
+    dev: true
+
+  /eslint-scope/5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
     dev: true
 
   /eslint-scope/7.1.1:
@@ -461,6 +641,11 @@ packages:
       estraverse: 5.3.0
     dev: true
 
+  /estraverse/4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
+    engines: {node: '>=4.0'}
+    dev: true
+
   /estraverse/5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
@@ -473,6 +658,17 @@ packages:
 
   /fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  /fast-glob/3.2.12:
+    resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
+    dev: true
 
   /fast-json-stable-stringify/2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -504,6 +700,13 @@ packages:
       token-types: 5.0.1
     dev: false
 
+  /fill-range/7.0.1:
+    resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      to-regex-range: 5.0.1
+    dev: true
+
   /find-up/5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -526,6 +729,13 @@ packages:
 
   /fs.realpath/1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+    dev: true
+
+  /glob-parent/5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+    dependencies:
+      is-glob: 4.0.3
     dev: true
 
   /glob-parent/6.0.2:
@@ -551,6 +761,18 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
+    dev: true
+
+  /globby/11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.2.12
+      ignore: 5.2.4
+      merge2: 1.4.1
+      slash: 3.0.0
     dev: true
 
   /grapheme-splitter/1.0.4:
@@ -604,6 +826,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
+    dev: true
+
+  /is-number/7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
     dev: true
 
   /is-path-inside/3.0.3:
@@ -661,8 +888,28 @@ packages:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: false
 
+  /lru-cache/6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+    dependencies:
+      yallist: 4.0.0
+    dev: true
+
   /make-error/1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: true
+
+  /merge2/1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+    dev: true
+
+  /micromatch/4.0.5:
+    resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
+    engines: {node: '>=8.6'}
+    dependencies:
+      braces: 3.0.2
+      picomatch: 2.3.1
     dev: true
 
   /minimatch/3.1.2:
@@ -673,6 +920,10 @@ packages:
 
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: true
+
+  /natural-compare-lite/1.4.0:
+    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
     dev: true
 
   /natural-compare/1.4.0:
@@ -733,14 +984,30 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /path-type/4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+    dev: true
+
   /peek-readable/5.0.0:
     resolution: {integrity: sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==}
     engines: {node: '>=14.16'}
     dev: false
 
+  /picomatch/2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+    dev: true
+
   /prelude-ls/1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+    dev: true
+
+  /prettier/2.8.4:
+    resolution: {integrity: sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
     dev: true
 
   /punycode/2.3.0:
@@ -800,6 +1067,14 @@ packages:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
     dev: false
 
+  /semver/7.3.8:
+    resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: true
+
   /shebang-command/2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -809,6 +1084,11 @@ packages:
 
   /shebang-regex/3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /slash/3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
     dev: true
 
@@ -854,6 +1134,13 @@ packages:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
 
+  /to-regex-range/5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+    dependencies:
+      is-number: 7.0.0
+    dev: true
+
   /token-types/5.0.1:
     resolution: {integrity: sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==}
     engines: {node: '>=14.16'}
@@ -897,8 +1184,23 @@ packages:
       yn: 3.1.1
     dev: true
 
+  /tslib/1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: true
+
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
+    dev: false
+
+  /tsutils/3.21.0_typescript@4.9.5:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.9.5
+    dev: true
 
   /type-check/0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -968,6 +1270,10 @@ packages:
       utf-8-validate:
         optional: true
     dev: false
+
+  /yallist/4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: true
 
   /yn/3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -12,6 +12,6 @@ const client = new Client({
 });
 
 loadFiles<Event<any>>("events")
-    .forEach(e => client.on(e.name, e.execute));
+  .then(events => events.forEach(e => client.on(e.name, e.execute)));
 
 client.login(token);

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -1,6 +1,6 @@
-import { Client, GatewayIntentBits } from "discord.js";
-import * as dotenv from "dotenv";
-import { loadFiles } from "./Helpers";
+import { Client, GatewayIntentBits } from 'discord.js';
+import * as dotenv from 'dotenv';
+import { loadFiles } from './Helpers';
 import Event from './Event';
 
 dotenv.config();
@@ -11,7 +11,8 @@ const client = new Client({
   intents: [GatewayIntentBits.Guilds],
 });
 
-loadFiles<Event<any>>("events")
-  .then(events => events.forEach(e => client.on(e.name, e.execute)));
+loadFiles<Event<never>>('events').then((events) =>
+  events.forEach((e) => client.on(e.name, e.execute)),
+);
 
 client.login(token);

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -1,15 +1,17 @@
-import { Client, ClientOptions } from "discord.js";
+import { Client, GatewayIntentBits } from "discord.js";
 import * as dotenv from "dotenv";
+import ready from "./events/ready";
+import interactionCreate from "./events/interactionCreate";
 
 dotenv.config();
 
 const token = process.env.TOKEN;
 
-console.log("Bot is starting...");
-
 const client = new Client({
-  intents: [],
+  intents: [GatewayIntentBits.Guilds],
 });
-client.login(token);
 
-console.log(client);
+ready(client);
+interactionCreate(client);
+
+client.login(token);

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -1,7 +1,7 @@
 import { Client, GatewayIntentBits } from "discord.js";
 import * as dotenv from "dotenv";
-import ready from "./events/ready";
-import interactionCreate from "./events/interactionCreate";
+import { loadFiles } from "./Helpers";
+import Event from './Event';
 
 dotenv.config();
 
@@ -11,7 +11,7 @@ const client = new Client({
   intents: [GatewayIntentBits.Guilds],
 });
 
-ready(client);
-interactionCreate(client);
+loadFiles<Event<any>>("events")
+    .forEach(e => client.on(e.name, e.execute));
 
 client.login(token);

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -1,9 +1,9 @@
-import {SlashCommandBuilder, CommandInteraction} from "discord.js";
+import {SlashCommandBuilder, ChatInputCommandInteraction} from "discord.js";
 
 export default class Command {
     constructor(
         public data: SlashCommandBuilder|Omit<SlashCommandBuilder, "addSubcommand" | "addSubcommandGroup">,
-        public execute: (interaction: CommandInteraction) => Promise<void>
+        public execute: (interaction: ChatInputCommandInteraction) => Promise<void>
     ) {
     }
 }

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -1,0 +1,6 @@
+import { SlashCommandBuilder, CommandInteraction } from "discord.js";
+
+export interface Command {
+    data: SlashCommandBuilder|Omit<SlashCommandBuilder, "addSubcommand" | "addSubcommandGroup">;
+    execute: (interaction: CommandInteraction) => Promise<void>;
+}

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -1,9 +1,10 @@
-import {SlashCommandBuilder, ChatInputCommandInteraction} from "discord.js";
+import { SlashCommandBuilder, ChatInputCommandInteraction } from 'discord.js';
 
 export default class Command {
-    constructor(
-        public data: SlashCommandBuilder|Omit<SlashCommandBuilder, "addSubcommand" | "addSubcommandGroup">,
-        public execute: (interaction: ChatInputCommandInteraction) => Promise<void>
-    ) {
-    }
+  constructor(
+    public data:
+      | SlashCommandBuilder
+      | Omit<SlashCommandBuilder, 'addSubcommand' | 'addSubcommandGroup'>,
+    public execute: (interaction: ChatInputCommandInteraction) => Promise<void>,
+  ) {}
 }

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -1,6 +1,9 @@
-import { SlashCommandBuilder, CommandInteraction } from "discord.js";
+import {SlashCommandBuilder, CommandInteraction} from "discord.js";
 
-export interface Command {
-    data: SlashCommandBuilder|Omit<SlashCommandBuilder, "addSubcommand" | "addSubcommandGroup">;
-    execute: (interaction: CommandInteraction) => Promise<void>;
+export default class Command {
+    constructor(
+        public data: SlashCommandBuilder|Omit<SlashCommandBuilder, "addSubcommand" | "addSubcommandGroup">,
+        public execute: (interaction: CommandInteraction) => Promise<void>
+    ) {
+    }
 }

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -1,20 +1,10 @@
-import fs from "fs";
-import path from "path";
 import { Collection } from "discord.js";
-import { Command } from "./Command";
-
-const extension = ".ts";
+import Command from "./Command";
+import { loadFiles } from "./Helpers";
 
 const commands : Collection<string, Command> = new Collection<string, Command>();
 
-const commandsPath = path.join(__dirname, "commands");
-const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith(extension));
-for (const file of commandFiles) {
-    const filePath = path.join(commandsPath, file);
-    const fileName = path.basename(file, extension);
-
-    const command: Command = require(filePath)[fileName];
-
+for (const command of loadFiles<Command>("commands")) {
     commands.set(command.data.name, command);
 }
 

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -4,8 +4,7 @@ import { loadFiles } from "./Helpers";
 
 const commands : Collection<string, Command> = new Collection<string, Command>();
 
-for (const command of loadFiles<Command>("commands")) {
-    commands.set(command.data.name, command);
-}
+loadFiles<Command>("commands")
+  .then(loadedCommands => loadedCommands.forEach(c => commands.set(c.data.name, c)))
 
 export default commands;

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -1,0 +1,21 @@
+import fs from "fs";
+import path from "path";
+import { Collection } from "discord.js";
+import { Command } from "./Command";
+
+const extension = ".ts";
+
+const commands : Collection<string, Command> = new Collection<string, Command>();
+
+const commandsPath = path.join(__dirname, "commands");
+const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith(extension));
+for (const file of commandFiles) {
+    const filePath = path.join(commandsPath, file);
+    const fileName = path.basename(file, extension);
+
+    const command: Command = require(filePath)[fileName];
+
+    commands.set(command.data.name, command);
+}
+
+export default commands;

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -1,10 +1,11 @@
-import { Collection } from "discord.js";
-import Command from "./Command";
-import { loadFiles } from "./Helpers";
+import { Collection } from 'discord.js';
+import Command from './Command';
+import { loadFiles } from './Helpers';
 
-const commands : Collection<string, Command> = new Collection<string, Command>();
+const commands: Collection<string, Command> = new Collection<string, Command>();
 
-loadFiles<Command>("commands")
-  .then(loadedCommands => loadedCommands.forEach(c => commands.set(c.data.name, c)))
+loadFiles<Command>('commands').then((loadedCommands) =>
+  loadedCommands.forEach((c) => commands.set(c.data.name, c)),
+);
 
 export default commands;

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -1,0 +1,9 @@
+import { Client, ClientEvents } from "discord.js";
+
+export default class Event<Key extends keyof ClientEvents> {
+    constructor(
+        public name: Key,
+        public execute: (...args: ClientEvents[Key]) => void
+    ) {
+    }
+}

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -1,9 +1,8 @@
-import { Client, ClientEvents } from "discord.js";
+import { ClientEvents } from 'discord.js';
 
 export default class Event<Key extends keyof ClientEvents> {
-    constructor(
-        public name: Key,
-        public execute: (...args: ClientEvents[Key]) => void
-    ) {
-    }
+  constructor(
+    public name: Key,
+    public execute: (...args: ClientEvents[Key]) => void,
+  ) {}
 }

--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -1,18 +1,23 @@
-import fs from "fs";
-import path from "path";
+import fs from 'fs';
+import path from 'path';
 
-export async function loadFiles<T>(directory: string, extension = ".ts"): Promise<T[]> {
-    const directoryPath = path.join(__dirname, directory);
+export async function loadFiles<T>(
+  directory: string,
+  extension = '.ts',
+): Promise<T[]> {
+  const directoryPath = path.join(__dirname, directory);
 
-    const files = fs.readdirSync(directoryPath).filter(file => file.endsWith(extension));
+  const files = fs
+    .readdirSync(directoryPath)
+    .filter((file) => file.endsWith(extension));
 
-    const results = [];
+  const results = [];
 
-    for (const file of files) {
-        const filePath = path.join(directoryPath, file);
+  for (const file of files) {
+    const filePath = path.join(directoryPath, file);
 
-        results.push((await import(filePath))['default']);
-    }
+    results.push((await import(filePath)).default);
+  }
 
-    return results;
+  return results;
 }

--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -1,0 +1,18 @@
+import fs from "fs";
+import path from "path";
+
+export function loadFiles<T>(directory: string, extension = ".ts"): T[] {
+    const directoryPath = path.join(__dirname, directory);
+
+    const files = fs.readdirSync(directoryPath).filter(file => file.endsWith(extension));
+
+    const results = [];
+
+    for (const file of files) {
+        const filePath = path.join(directoryPath, file);
+
+        results.push(require(filePath)['default']);
+    }
+
+    return results;
+}

--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 
-export function loadFiles<T>(directory: string, extension = ".ts"): T[] {
+export async function loadFiles<T>(directory: string, extension = ".ts"): Promise<T[]> {
     const directoryPath = path.join(__dirname, directory);
 
     const files = fs.readdirSync(directoryPath).filter(file => file.endsWith(extension));
@@ -11,7 +11,7 @@ export function loadFiles<T>(directory: string, extension = ".ts"): T[] {
     for (const file of files) {
         const filePath = path.join(directoryPath, file);
 
-        results.push(require(filePath)['default']);
+        results.push((await import(filePath))['default']);
     }
 
     return results;

--- a/src/commandHandler.ts
+++ b/src/commandHandler.ts
@@ -1,0 +1,25 @@
+import { Interaction } from "discord.js";
+import Commands from "./Commands";
+
+export default async(interaction: Interaction): Promise<void> => {
+    if(!interaction.isChatInputCommand()) {
+        return;
+    }
+
+    const command = Commands.get(interaction.commandName);
+    if(!command) {
+        console.error(`No command matching ${interaction.commandName} was found.`);
+        return;
+    }
+
+    try {
+        await command.execute(interaction);
+    } catch (error) {
+        console.error(error);
+
+        await interaction.followUp({
+            content: "There was an error while executing this command!",
+            ephemeral: true
+        });
+    }
+}

--- a/src/commandHandler.ts
+++ b/src/commandHandler.ts
@@ -1,25 +1,25 @@
-import { Interaction } from "discord.js";
-import Commands from "./Commands";
+import { Interaction } from 'discord.js';
+import Commands from './Commands';
 
-export default async(interaction: Interaction): Promise<void> => {
-    if(!interaction.isChatInputCommand()) {
-        return;
-    }
+export default async (interaction: Interaction): Promise<void> => {
+  if (!interaction.isChatInputCommand()) {
+    return;
+  }
 
-    const command = Commands.get(interaction.commandName);
-    if(!command) {
-        console.error(`No command matching ${interaction.commandName} was found.`);
-        return;
-    }
+  const command = Commands.get(interaction.commandName);
+  if (!command) {
+    console.error(`No command matching ${interaction.commandName} was found.`);
+    return;
+  }
 
-    try {
-        await command.execute(interaction);
-    } catch (error) {
-        console.error(error);
+  try {
+    await command.execute(interaction);
+  } catch (error) {
+    console.error(error);
 
-        await interaction.followUp({
-            content: "There was an error while executing this command!",
-            ephemeral: true
-        });
-    }
-}
+    await interaction.followUp({
+      content: 'There was an error while executing this command!',
+      ephemeral: true,
+    });
+  }
+};

--- a/src/commands/Hello.ts
+++ b/src/commands/Hello.ts
@@ -1,0 +1,29 @@
+import { SlashCommandBuilder } from "discord.js";
+import { Command } from "../Command";
+
+export const Hello: Command = {
+    data: new SlashCommandBuilder()
+        .setName("hello")
+        .setDescription("Introduce yourself to the community")
+        .addStringOption(option =>
+            option.setName("experience")
+                .setDescription("Your current professional experience level?")
+                .setRequired(false)
+                .addChoices(
+                    { name: "Student", value: "student" },
+                    { name: "Junior", value: "junior" },
+                    { name: "Medior", value: "medior" },
+                    { name: "Senior", value: "senior" }
+                )
+        ),
+    execute: async (interaction) => {
+        const experience = interaction.options.get("experience");
+
+        const content = `Your experience is: ${experience?.value ?? "Unknown"}`;
+
+        await interaction.reply({
+            ephemeral: true,
+            content
+        });
+    }
+};

--- a/src/commands/Hello.ts
+++ b/src/commands/Hello.ts
@@ -1,29 +1,30 @@
-import { SlashCommandBuilder } from "discord.js";
-import Command from "../Command";
+import { SlashCommandBuilder } from 'discord.js';
+import Command from '../Command';
 
 export default new Command(
-    new SlashCommandBuilder()
-        .setName("hello")
-        .setDescription("Introduce yourself to the community")
-        .addStringOption(option =>
-            option.setName("experience")
-                .setDescription("Your current professional experience level?")
-                .setRequired(false)
-                .addChoices(
-                    { name: "Student", value: "student" },
-                    { name: "Junior", value: "junior" },
-                    { name: "Medior", value: "medior" },
-                    { name: "Senior", value: "senior" }
-                )
+  new SlashCommandBuilder()
+    .setName('hello')
+    .setDescription('Introduce yourself to the community')
+    .addStringOption((option) =>
+      option
+        .setName('experience')
+        .setDescription('Your current professional experience level?')
+        .setRequired(false)
+        .addChoices(
+          { name: 'Student', value: 'student' },
+          { name: 'Junior', value: 'junior' },
+          { name: 'Medior', value: 'medior' },
+          { name: 'Senior', value: 'senior' },
         ),
-    async (interaction) => {
-        const experience = interaction.options.getString("experience");
+    ),
+  async (interaction) => {
+    const experience = interaction.options.getString('experience');
 
-        const content = `Your experience is: ${experience ?? "Unknown"}`;
+    const content = `Your experience is: ${experience ?? 'Unknown'}`;
 
-        await interaction.reply({
-            ephemeral: true,
-            content
-        });
-    }
+    await interaction.reply({
+      ephemeral: true,
+      content,
+    });
+  },
 );

--- a/src/commands/Hello.ts
+++ b/src/commands/Hello.ts
@@ -1,8 +1,8 @@
 import { SlashCommandBuilder } from "discord.js";
-import { Command } from "../Command";
+import Command from "../Command";
 
-export const Hello: Command = {
-    data: new SlashCommandBuilder()
+export default new Command(
+    new SlashCommandBuilder()
         .setName("hello")
         .setDescription("Introduce yourself to the community")
         .addStringOption(option =>
@@ -16,7 +16,7 @@ export const Hello: Command = {
                     { name: "Senior", value: "senior" }
                 )
         ),
-    execute: async (interaction) => {
+    async (interaction) => {
         const experience = interaction.options.get("experience");
 
         const content = `Your experience is: ${experience?.value ?? "Unknown"}`;
@@ -26,4 +26,4 @@ export const Hello: Command = {
             content
         });
     }
-};
+);

--- a/src/commands/Hello.ts
+++ b/src/commands/Hello.ts
@@ -17,9 +17,9 @@ export default new Command(
                 )
         ),
     async (interaction) => {
-        const experience = interaction.options.get("experience");
+        const experience = interaction.options.getString("experience");
 
-        const content = `Your experience is: ${experience?.value ?? "Unknown"}`;
+        const content = `Your experience is: ${experience ?? "Unknown"}`;
 
         await interaction.reply({
             ephemeral: true,

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,7 +1,10 @@
-import { Interaction } from "discord.js";
-import commandHandler from "../commandHandler";
-import Event from "../Event";
+import { Interaction } from 'discord.js';
+import commandHandler from '../commandHandler';
+import Event from '../Event';
 
-export default new Event("interactionCreate", async(interaction: Interaction) => {
+export default new Event(
+  'interactionCreate',
+  async (interaction: Interaction) => {
     await commandHandler(interaction);
-});
+  },
+);

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,0 +1,8 @@
+import { Client, Events, Interaction } from "discord.js";
+import commandHandler from "../commandHandler";
+
+export default (client: Client): void => {
+    client.on(Events.InteractionCreate, async(interaction: Interaction) => {
+        await commandHandler(interaction);
+    });
+};

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,8 +1,7 @@
-import { Client, Events, Interaction } from "discord.js";
+import { Interaction } from "discord.js";
 import commandHandler from "../commandHandler";
+import Event from "../Event";
 
-export default (client: Client): void => {
-    client.on(Events.InteractionCreate, async(interaction: Interaction) => {
-        await commandHandler(interaction);
-    });
-};
+export default new Event("interactionCreate", async(interaction: Interaction) => {
+    await commandHandler(interaction);
+});

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,41 +1,42 @@
-import { Client, REST, Routes } from "discord.js";
-import Event from "../Event";
-import Commands from "../Commands";
+import { Client, REST, Routes } from 'discord.js';
+import Event from '../Event';
+import Commands from '../Commands';
 
-export default new Event("ready", async (client: Client) => {
-    if(!client.user || !client.application) {
-        return;
-    }
+export default new Event('ready', async (client: Client) => {
+  if (!client.user || !client.application) {
+    return;
+  }
 
-    await registerCommands();
+  await registerCommands();
 
-    console.log(`${client.user.tag} is online`);
+  console.log(`${client.user.tag} is online`);
 });
 
-const registerCommands = async() => {
-    const commands = Commands.map(c => c.data.toJSON());
+const registerCommands = async () => {
+  const commands = Commands.map((c) => c.data.toJSON());
 
-    const token = process.env.TOKEN;
-    const applicationId = process.env.APPLICATION_ID;
-    const guildId = process.env.GUILD_ID;
+  const token = process.env.TOKEN;
+  const applicationId = process.env.APPLICATION_ID;
+  const guildId = process.env.GUILD_ID;
 
-    if(!token || !applicationId || !guildId) {
-        console.warn("Secrets are not set in .env. Bot commands will not be registered.");
-        return;
-    }
+  if (!token || !applicationId || !guildId) {
+    console.warn(
+      'Secrets are not set in .env. Bot commands will not be registered.',
+    );
+    return;
+  }
 
-    const rest = new REST().setToken(token);
+  const rest = new REST().setToken(token);
 
-    try {
-        console.log(`Registering ${commands.length} bot (/) commands`);
+  try {
+    console.log(`Registering ${commands.length} bot (/) commands`);
 
-        await rest.put(
-            Routes.applicationGuildCommands(applicationId, guildId),
-            { body: commands }
-        );
+    await rest.put(Routes.applicationGuildCommands(applicationId, guildId), {
+      body: commands,
+    });
 
-        console.log(`Successfully registered bot (/) commands.`);
-    } catch (error) {
-        console.error(error);
-    }
+    console.log(`Successfully registered bot (/) commands.`);
+  } catch (error) {
+    console.error(error);
+  }
 };

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,4 +1,4 @@
-import { Client, Events } from "discord.js";
+import { Client, Events, REST, Routes } from "discord.js";
 import Commands from "../Commands";
 
 export default (client: Client): void => {
@@ -7,9 +7,36 @@ export default (client: Client): void => {
             return;
         }
 
-        const commands = Commands.map(c => c.data);
-        await client.application.commands.set(commands);
+        await registerCommands();
 
         console.log(`${client.user.tag} is online`);
     });
 }
+
+const registerCommands = async() => {
+    const commands = Commands.map(c => c.data.toJSON());
+
+    const token = process.env.TOKEN;
+    const applicationId = process.env.APPLICATION_ID;
+    const guildId = process.env.GUILD_ID;
+
+    if(!token || !applicationId || !guildId) {
+        console.warn("Secrets are not set in .env. Bot commands will not be registered.");
+        return;
+    }
+
+    const rest = new REST().setToken(token);
+
+    try {
+        console.log(`Registering ${commands.length} bot (/) commands`);
+
+        await rest.put(
+            Routes.applicationGuildCommands(applicationId, guildId),
+            { body: commands }
+        );
+
+        console.log(`Successfully registered bot (/) commands.`);
+    } catch (error) {
+        console.error(error);
+    }
+};

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,0 +1,15 @@
+import { Client, Events } from "discord.js";
+import Commands from "../Commands";
+
+export default (client: Client): void => {
+    client.on(Events.ClientReady, async() => {
+        if(!client.user || !client.application) {
+            return;
+        }
+
+        const commands = Commands.map(c => c.data);
+        await client.application.commands.set(commands);
+
+        console.log(`${client.user.tag} is online`);
+    });
+}

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,17 +1,16 @@
-import { Client, Events, REST, Routes } from "discord.js";
+import { Client, REST, Routes } from "discord.js";
+import Event from "../Event";
 import Commands from "../Commands";
 
-export default (client: Client): void => {
-    client.on(Events.ClientReady, async() => {
-        if(!client.user || !client.application) {
-            return;
-        }
+export default new Event("ready", async (client: Client) => {
+    if(!client.user || !client.application) {
+        return;
+    }
 
-        await registerCommands();
+    await registerCommands();
 
-        console.log(`${client.user.tag} is online`);
-    });
-}
+    console.log(`${client.user.tag} is online`);
+});
 
 const registerCommands = async() => {
     const commands = Commands.map(c => c.data.toJSON());


### PR DESCRIPTION
# Introdution
I saw some confusion within the Discord channel about how to get commands setup using TS (since the `commands` property doesn't exist on the type `Client`).

This serves as a starting example of how this can be accomplished.

# Project Structure
First, I'll start with the project structure. It's quite a simple structure given the scope of the bot so far:

## Directories
- `commands`: This folder contains every command the bot should register and listen to. Each command should be separated into its own file (better separation of concerns = better coding standards = easy and enjoyable maintenance). **NOTE: See how commands are registered below**.
- `events`: This folder contains every event dispatched from `Discord.js`. Each event should also be separted into its own file (similar to above). [Here's more information on the events that are dispatched](https://discord.js.org/#/docs/discord.js/main/typedef/Events).

## Files
- `Bot.ts`: This is the entry-point of the bot. It loads the secrets/variables stored in `.env` (never, ever share `.env`). It also initialises the `Discord.js` client and registers the events and commands.
- `Command.ts`: This defines the interface every command has to adhere to. This helps ensure the code-base is consitent (among many other things I won't list here) ultimately preventing runtime errors.
- `commandHandler.ts`: This is the callback for every command. It's what looks up and executes every command based on what was written in the Discord channel. It only forwards on the `Interaction` to the command, but that should be sufficient.
- `Commands.ts`: This serves as the lookup of every command. It utilises `Discord.js`'s own `Collection` class, and provides as key-value lookup of every command. This is first used when registering the commands with Discord, but is also used when executing a command.

## Example command
I've included an example command called `Hello` at `commands/Hello.ts`, this can be invoked in Discord by using `/hello`. Currently, this command doesn't do much, but it provides an example of allowing a community member to introduce themselves by providing their experience level (from a predefined list).

I envision this command having more options (such as country, timezone, and role/interest such as front-end and back-end). It'll then update the user's roles, etc. based on what their inputs were.

Currently this command will just reply back with the experience level that was chosen. I am conscious of an issue where I can't use the `getString` function to get the value of an option ([like documented here](https://discordjs.guide/slash-commands/parsing-options.html#command-options)). I'm not entirely sure why yet (I'm sure it's a type related issue that's causing TS to complain) though I will investigate further once I have some more time.

## Okay, so how are commands registered then?
We hook into the `ready` event that is dispatched by `Discord.js` inside `events/ready.ts`. This uses the lookup that's loaded inside `Commands.ts`. I chose to load each command automatically via requiring each file, I personally prefer this approach over manually importing every command (this can quickly grow out of hand on larger projects, _but could be considered over-enginerring for smaller projects_).

Once caveat of this approach is we need to define the name of the command we're exporting in each file (such as inside `commands/Hello.ts`. To handle this, I've required every command to have the command exported the same as the file name. This shouldn't be a problem since they _shouldn't_ be different anyway. An alternative solution to this is have every command export the same name.

To see what I mean, you can see at `Commands.ts:16` I've loaded the file containing the command code, and then I'm accessing the actual command by the name of the file (which again, should be the name of the command anyway).

## Summary
This isn't a finished solution (hence the draft). It does what it's supposed to do (from my limited testing lol) but it should serve as a starting point (or at least a reference point) to adding the commands that we want to support. I've added an example command to help share my vision of this working, but it's obviously very basic.